### PR TITLE
Add FX Range Accrual Fixe Rate Coupon

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -819,6 +819,7 @@
     <ClInclude Include="ql\indexes\all.hpp" />
     <ClInclude Include="ql\indexes\bmaindex.hpp" />
     <ClInclude Include="ql\indexes\equityindex.hpp" />
+    <ClInclude Include="ql\indexes\fxindex.hpp" />
     <ClInclude Include="ql\indexes\ibor\all.hpp" />
     <ClInclude Include="ql\indexes\ibor\aonia.hpp" />
     <ClInclude Include="ql\indexes\ibor\audlibor.hpp" />
@@ -2125,6 +2126,7 @@
     <ClCompile Include="ql\experimental\volatility\zabr.cpp" />
     <ClCompile Include="ql\indexes\bmaindex.cpp" />
     <ClCompile Include="ql\indexes\equityindex.cpp" />
+    <ClCompile Include="ql\indexes\fxindex.cpp" />
     <ClCompile Include="ql\indexes\ibor\bibor.cpp" />
     <ClCompile Include="ql\indexes\ibor\corra.cpp" />
     <ClCompile Include="ql\indexes\ibor\eonia.cpp" />

--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -520,6 +520,7 @@
     <ClInclude Include="ql\cashflows\equitycashflow.hpp" />
     <ClInclude Include="ql\cashflows\fixedratecoupon.hpp" />
     <ClInclude Include="ql\cashflows\floatingratecoupon.hpp" />
+    <ClInclude Include="ql\cashflows\fxrangeaccrualfixed.hpp" />
     <ClInclude Include="ql\cashflows\iborcoupon.hpp" />
     <ClInclude Include="ql\cashflows\indexedcashflow.hpp" />
     <ClInclude Include="ql\cashflows\inflationcoupon.hpp" />
@@ -1924,6 +1925,7 @@
     <ClCompile Include="ql\cashflows\equitycashflow.cpp" />
     <ClCompile Include="ql\cashflows\fixedratecoupon.cpp" />
     <ClCompile Include="ql\cashflows\floatingratecoupon.cpp" />
+    <ClCompile Include="ql\cashflows\fxrangeaccrualfixed.cpp" />
     <ClCompile Include="ql\cashflows\iborcoupon.cpp" />
     <ClCompile Include="ql\cashflows\indexedcashflow.cpp" />
     <ClCompile Include="ql\cashflows\inflationcoupon.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -4467,6 +4467,9 @@
     <ClInclude Include="ql\indexes\fxindex.hpp">
       <Filter>indexes</Filter>
     </ClInclude>
+    <ClInclude Include="ql\cashflows\fxrangeaccrualfixed.hpp">
+      <Filter>cashflows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ql\methods\montecarlo\brownianbridge.cpp">
@@ -7221,6 +7224,9 @@
     </ClCompile>
     <ClCompile Include="ql\indexes\fxindex.cpp">
       <Filter>indexes</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\cashflows\fxrangeaccrualfixed.cpp">
+      <Filter>cashflows</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -4464,6 +4464,9 @@
     <ClInclude Include="ql\indexes\ibor\swestr.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
+    <ClInclude Include="ql\indexes\fxindex.hpp">
+      <Filter>indexes</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ql\methods\montecarlo\brownianbridge.cpp">
@@ -7215,6 +7218,9 @@
     </ClCompile>
     <ClCompile Include="ql\time\daycounters\yearfractiontodate.cpp">
       <Filter>time\daycounters</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\indexes\fxindex.cpp">
+      <Filter>indexes</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -228,6 +228,7 @@ set(QL_SOURCES
     index.cpp
     indexes/bmaindex.cpp
     indexes/equityindex.cpp
+    indexes/fxindex.cpp
     indexes/ibor/bibor.cpp
     indexes/ibor/corra.cpp
     indexes/ibor/eonia.cpp
@@ -1242,6 +1243,7 @@ set(QL_HEADERS
     index.hpp
     indexes/bmaindex.hpp
     indexes/equityindex.hpp
+    indexes/fxindex.hpp
     indexes/ibor/aonia.hpp
     indexes/ibor/audlibor.hpp
     indexes/ibor/bbsw.hpp

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -19,6 +19,7 @@ set(QL_SOURCES
     cashflows/equitycashflow.cpp
     cashflows/fixedratecoupon.cpp
     cashflows/floatingratecoupon.cpp
+    cashflows/fxrangeaccrualfixed.cpp
     cashflows/iborcoupon.cpp
     cashflows/indexedcashflow.cpp
     cashflows/inflationcoupon.cpp
@@ -957,6 +958,7 @@ set(QL_HEADERS
     cashflows/equitycashflow.hpp
     cashflows/fixedratecoupon.hpp
     cashflows/floatingratecoupon.hpp
+    cashflows/fxrangeaccrualfixed.hpp
     cashflows/iborcoupon.hpp
     cashflows/indexedcashflow.hpp
     cashflows/inflationcoupon.hpp

--- a/ql/cashflows/Makefile.am
+++ b/ql/cashflows/Makefile.am
@@ -23,6 +23,7 @@ this_include_HEADERS = \
     equitycashflow.hpp \
     fixedratecoupon.hpp \
     floatingratecoupon.hpp \
+    fxrangeaccrualfixed.hpp \
     iborcoupon.hpp \
     indexedcashflow.hpp \
     inflationcoupon.hpp \
@@ -58,6 +59,7 @@ cpp_files = \
     equitycashflow.cpp \
     fixedratecoupon.cpp \
     floatingratecoupon.cpp \
+    fxrangeaccrualfixed.cpp \
     iborcoupon.cpp \
     indexedcashflow.cpp \
     inflationcoupon.cpp \

--- a/ql/cashflows/all.hpp
+++ b/ql/cashflows/all.hpp
@@ -20,6 +20,7 @@
 #include <ql/cashflows/equitycashflow.hpp>
 #include <ql/cashflows/fixedratecoupon.hpp>
 #include <ql/cashflows/floatingratecoupon.hpp>
+#include <ql/cashflows/fxrangeaccrualfixed.hpp>
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/cashflows/indexedcashflow.hpp>
 #include <ql/cashflows/inflationcoupon.hpp>

--- a/ql/cashflows/fxrangeaccrualfixed.cpp
+++ b/ql/cashflows/fxrangeaccrualfixed.cpp
@@ -27,6 +27,7 @@
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/pricingengines/blackformula.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp>
 #include <ql/time/schedule.hpp>
 #include <cmath>
 #include <utility>
@@ -60,7 +61,12 @@ namespace QuantLib {
                       refPeriodEnd,
                       exCouponDate),
       observationsSchedule_(std::move(observationsSchedule)), fxIndex_(std::move(fxIndex)),
-      lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), pricer_(0), rangeAccrual_(0.0) {}
+      lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), pricer_(0), rangeAccrual_(0.0) {
+        QL_REQUIRE(observationsSchedule_, "observationsSchedule_ required.");
+        QL_REQUIRE(fxIndex_, "fxIndex_ required.");
+        QL_REQUIRE(lowerTrigger_ > 0.0, "lowerTrigger_ > 0.0 required.");
+        QL_REQUIRE(lowerTrigger_ < upperTrigger_, "lowerTrigger_ < upperTrigger_ required.");
+    }
 
 
     FxRangeAccrualFixedCoupon::FxRangeAccrualFixedCoupon(
@@ -96,7 +102,12 @@ namespace QuantLib {
                                     .withCalendar(fxIndex->fixingCalendar())
                                     .withConvention(Following))),
     fxIndex_(std::move(fxIndex)),
-    lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), pricer_(0), rangeAccrual_(0.0) {}
+    lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), pricer_(0), rangeAccrual_(0.0) {
+        QL_REQUIRE(observationsSchedule_, "observationsSchedule_ required.");
+        QL_REQUIRE(fxIndex_, "fxIndex_ required.");
+        QL_REQUIRE(lowerTrigger_ > 0.0, "lowerTrigger_ > 0.0 required.");
+        QL_REQUIRE(lowerTrigger_ < upperTrigger_, "lowerTrigger_ < upperTrigger_ required.");
+    }
 
 
     void FxRangeAccrualFixedCoupon::performCalculations() const {
@@ -104,6 +115,7 @@ namespace QuantLib {
         if (pricer_) {
             pricer_->initialize(*this);
             rangeAccrual_ = pricer_->rangeAccrual();
+            additionalResults_ = pricer_->additionalResults();
         } else {
             // calculate fall-back via intrinsic value
             Real inRange = 0.0;
@@ -150,8 +162,46 @@ namespace QuantLib {
     ) : fxVolatility_(fxVolatility), rangeAccrual_(Null<Real>()) {}
 
     void FxRangeAccrualFixedCouponPricer::initialize(const FxRangeAccrualFixedCoupon& coupon) {
+        additionalResults_.clear();
         // implement rangeAccrual_ calculation...
-        rangeAccrual_ = 0.123;
+        Real minStd = 0.0005;  // 1% * sqrt(1d)
+        CumulativeNormalDistribution Phi;
+        Real daysInRange = 0.0;
+        for (auto d : coupon.observationsSchedule()->dates()) {
+            std::ostringstream s;
+            s << io::iso_date(d);
+            std::string date_s = s.str();
+            Real indexObservation = coupon.fxIndex()->fixing(d);
+            Real standardDevLow = 0.0;
+            Real standardDevUpp = 0.0;
+            if (d > fxVolatility_->referenceDate()) {
+                standardDevLow = fxVolatility_->blackVariance(d, coupon.lowerTrigger(), true);
+                standardDevUpp = fxVolatility_->blackVariance(d, coupon.upperTrigger(), true);
+            }
+            Real inRangeProbability = 0.0;
+            if (standardDevLow < minStd) {  // calculate intrinsic value
+                if (indexObservation >= coupon.lowerTrigger() &&
+                    indexObservation <= coupon.upperTrigger())
+                    inRangeProbability = 1.0;
+            } else {  // put option spread valuation
+                Real d2Lower = std::log(indexObservation / coupon.lowerTrigger()) / standardDevLow -
+                               0.5 * standardDevLow;
+                Real d2Upper = std::log(indexObservation / coupon.upperTrigger()) / standardDevUpp -
+                               0.5 * standardDevUpp;
+                Real putLower = Phi(-d2Lower);
+                Real putUpper = Phi(-d2Upper);
+                inRangeProbability = putUpper - putLower;
+            }
+            daysInRange += inRangeProbability;
+            //
+            additionalResults_["indexObservation_" + date_s] = indexObservation;
+            additionalResults_["standardDevLow_" + date_s] = standardDevLow;
+            additionalResults_["standardDevUpp_" + date_s] = standardDevUpp;
+            additionalResults_["inRangeProbability_" + date_s] = inRangeProbability;
+        }
+        rangeAccrual_ = daysInRange / coupon.observationsSchedule()->dates().size();
+        additionalResults_["daysInRange"] = daysInRange;
+        additionalResults_["observationDays"] = (Real) coupon.observationsSchedule()->dates().size();
     }
 
     Real FxRangeAccrualFixedCouponPricer::rangeAccrual() const {

--- a/ql/cashflows/fxrangeaccrualfixed.cpp
+++ b/ql/cashflows/fxrangeaccrualfixed.cpp
@@ -1,0 +1,132 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2006, 2007 Giorgio Facchinetti
+ Copyright (C) 2006, 2007 Mario Pucci
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+
+#include <ql/cashflows/cashflowvectors.hpp>
+#include <ql/cashflows/fxrangeaccrualfixed.hpp>
+#include <ql/indexes/fxindex.hpp>
+#include <ql/math/distributions/normaldistribution.hpp>
+#include <ql/pricingengines/blackformula.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/time/schedule.hpp>
+#include <cmath>
+#include <utility>
+
+namespace QuantLib {
+
+    FxRangeAccrualFixedCoupon::FxRangeAccrualFixedCoupon(
+        // FixedRateCoupon
+        const Date& paymentDate,
+        Real nominal,
+        Real rate,
+        const DayCounter& dayCounter,
+        const Date& accrualStartDate,
+        const Date& accrualEndDate,
+        // RA feature
+        ext::shared_ptr<Schedule> observationsSchedule,
+        ext::shared_ptr<FxIndex> fxIndex,
+        Real lowerTrigger,
+        Real upperTrigger,
+        // optional FixedRateCoupon
+        const Date& refPeriodStart,
+        const Date& refPeriodEnd,
+        const Date& exCouponDate)
+    : FixedRateCoupon(paymentDate,
+                      nominal,
+                      rate,
+                      dayCounter,
+                      accrualStartDate,
+                      accrualEndDate,
+                      refPeriodStart,
+                      refPeriodEnd,
+                      exCouponDate),
+      observationsSchedule_(std::move(observationsSchedule)), fxIndex_(std::move(fxIndex)),
+      lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), rangeAccrual_(0.0) {} 
+
+
+    FxRangeAccrualFixedCoupon::FxRangeAccrualFixedCoupon(
+        // FixedRateCoupon
+        const Date& paymentDate,
+        Real nominal,
+        Real rate,
+        const DayCounter& dayCounter,
+        const Date& accrualStartDate,
+        const Date& accrualEndDate,
+        // RA feature
+        // calculate observation schedule from coupon
+        ext::shared_ptr<FxIndex> fxIndex,
+        Real lowerTrigger,
+        Real upperTrigger,
+        // optional FixedRateCoupon
+        const Date& refPeriodStart,
+        const Date& refPeriodEnd,
+        const Date& exCouponDate)
+    : FixedRateCoupon(paymentDate,
+                      nominal,
+                      rate,
+                      dayCounter,
+                      accrualStartDate,
+                      accrualEndDate,
+                      refPeriodStart,
+                      refPeriodEnd,
+                      exCouponDate),
+      fxIndex_(std::move(fxIndex)), lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger),
+        observationsSchedule_(ext::make_shared<Schedule>(MakeSchedule()
+                                    .from(accrualStartDate)
+                                    .to(accrualEndDate)
+                                    .withFrequency(Daily)
+                                    .withCalendar(fxIndex->fixingCalendar())
+                                    .withConvention(Following))), rangeAccrual_(0.0) {  } 
+
+
+    void FxRangeAccrualFixedCoupon::performCalculations() const {
+        FixedRateCoupon::performCalculations();
+        // more stuff
+        Real inRange = 0.0;
+        for (auto d : observationsSchedule()->dates()) {
+            auto indexObservation = fxIndex()->fixing(d);
+            if (indexObservation >= lowerTrigger() && indexObservation <= upperTrigger())
+                inRange += 1.0;
+        }
+        rangeAccrual_ = inRange / observationsSchedule()->dates().size();
+    }
+
+    Real FxRangeAccrualFixedCoupon::rangeAccrual() const {
+        calculate();  // make sure member is calculated
+        return rangeAccrual_;
+    }
+
+
+    Real FxRangeAccrualFixedCoupon::amount() const {
+        calculate();
+        return rangeAccrual_ * FixedRateCoupon::amount();
+    }
+
+
+    void FxRangeAccrualFixedCoupon::accept(AcyclicVisitor& v) {
+        auto* v1 = dynamic_cast<Visitor<FxRangeAccrualFixedCoupon>*>(&v);
+        if (v1 != nullptr)
+            v1->visit(*this);
+        else
+            FixedRateCoupon::accept(v);
+    }
+
+
+}

--- a/ql/cashflows/fxrangeaccrualfixed.cpp
+++ b/ql/cashflows/fxrangeaccrualfixed.cpp
@@ -87,13 +87,14 @@ namespace QuantLib {
                       refPeriodStart,
                       refPeriodEnd,
                       exCouponDate),
-      fxIndex_(std::move(fxIndex)), lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger),
+      fxIndex_(std::move(fxIndex)),
         observationsSchedule_(ext::make_shared<Schedule>(MakeSchedule()
                                     .from(accrualStartDate)
                                     .to(accrualEndDate)
                                     .withFrequency(Daily)
                                     .withCalendar(fxIndex->fixingCalendar())
-                                    .withConvention(Following))), rangeAccrual_(0.0) {  } 
+                                                           .withConvention(Following))),
+      lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), rangeAccrual_(0.0) {}
 
 
     void FxRangeAccrualFixedCoupon::performCalculations() const {

--- a/ql/cashflows/fxrangeaccrualfixed.cpp
+++ b/ql/cashflows/fxrangeaccrualfixed.cpp
@@ -87,14 +87,14 @@ namespace QuantLib {
                       refPeriodStart,
                       refPeriodEnd,
                       exCouponDate),
-      fxIndex_(std::move(fxIndex)),
-        observationsSchedule_(ext::make_shared<Schedule>(MakeSchedule()
+    observationsSchedule_(ext::make_shared<Schedule>(MakeSchedule()
                                     .from(accrualStartDate)
                                     .to(accrualEndDate)
                                     .withFrequency(Daily)
                                     .withCalendar(fxIndex->fixingCalendar())
-                                                           .withConvention(Following))),
-      lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), rangeAccrual_(0.0) {}
+                                    .withConvention(Following))),
+    fxIndex_(std::move(fxIndex)),
+    lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), rangeAccrual_(0.0) {}
 
 
     void FxRangeAccrualFixedCoupon::performCalculations() const {

--- a/ql/cashflows/fxrangeaccrualfixed.hpp
+++ b/ql/cashflows/fxrangeaccrualfixed.hpp
@@ -100,6 +100,8 @@ namespace QuantLib {
 
         void setPricer(const ext::shared_ptr<FxRangeAccrualFixedCouponPricer>&);
 
+        std::map<std::string, Real>& additionalResults() const { return additionalResults_; }
+
       private:
 
         const ext::shared_ptr<Schedule> observationsSchedule_;
@@ -110,6 +112,7 @@ namespace QuantLib {
 
         ext::shared_ptr<FxRangeAccrualFixedCouponPricer> pricer_;
         mutable Real rangeAccrual_;
+        mutable std::map<std::string, Real> additionalResults_;
      };
 
 
@@ -126,6 +129,8 @@ namespace QuantLib {
 
         Real rangeAccrual() const;
 
+        std::map<std::string, Real>& additionalResults() const { return additionalResults_; }
+
       //! \name Observer interface
       //@{
       void update() override { notifyObservers(); }
@@ -134,6 +139,7 @@ namespace QuantLib {
       protected:
         Handle<BlackVolTermStructure> fxVolatility_;
         Real rangeAccrual_;
+        mutable std::map<std::string, Real> additionalResults_;
     };
 
 }

--- a/ql/cashflows/fxrangeaccrualfixed.hpp
+++ b/ql/cashflows/fxrangeaccrualfixed.hpp
@@ -34,7 +34,8 @@
 namespace QuantLib {
 
     class FxIndex;
-    class FxRangeAccrualFixePricer;
+    class BlackVolTermStructure;
+    class FxRangeAccrualFixedCouponPricer;
 
     class FxRangeAccrualFixedCoupon: public FixedRateCoupon {
 
@@ -96,6 +97,9 @@ namespace QuantLib {
         //@{
         void accept(AcyclicVisitor&) override;
         //@}
+
+        void setPricer(const ext::shared_ptr<FxRangeAccrualFixedCouponPricer>&);
+
       private:
 
         const ext::shared_ptr<Schedule> observationsSchedule_;
@@ -104,9 +108,33 @@ namespace QuantLib {
         Real lowerTrigger_;
         Real upperTrigger_;
 
+        ext::shared_ptr<FxRangeAccrualFixedCouponPricer> pricer_;
         mutable Real rangeAccrual_;
      };
 
+
+    class FxRangeAccrualFixedCouponPricer
+    : public virtual Observer,
+      public virtual Observable {
+      public:
+
+        FxRangeAccrualFixedCouponPricer(
+            Handle<BlackVolTermStructure> fxVolatility
+        );
+
+        void initialize(const FxRangeAccrualFixedCoupon& coupon);
+
+        Real rangeAccrual() const;
+
+      //! \name Observer interface
+      //@{
+      void update() override { notifyObservers(); }
+      //@}
+
+      protected:
+        Handle<BlackVolTermStructure> fxVolatility_;
+        Real rangeAccrual_;
+    };
 
 }
 

--- a/ql/cashflows/fxrangeaccrualfixed.hpp
+++ b/ql/cashflows/fxrangeaccrualfixed.hpp
@@ -1,0 +1,114 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+
+ Copyright (C) 2006, 2007 Giorgio Facchinetti
+ Copyright (C) 2006, 2007 Mario Pucci
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file rangeaccrual.hpp
+    \brief range-accrual coupon
+*/
+
+#ifndef quantlib_fx_range_accrual_fixed_h
+#define quantlib_fx_range_accrual_fixed_h
+
+#include <ql/cashflows/couponpricer.hpp>
+#include <ql/cashflows/fixedratecoupon.hpp>
+#include <ql/time/schedule.hpp>
+#include <vector>
+
+namespace QuantLib {
+
+    class FxIndex;
+    class FxRangeAccrualFixePricer;
+
+    class FxRangeAccrualFixedCoupon: public FixedRateCoupon {
+
+      public:
+        FxRangeAccrualFixedCoupon(
+		    // FixedRateCoupon
+		    const Date& paymentDate,
+            Real nominal,
+            Real rate,
+            const DayCounter& dayCounter,
+            const Date& accrualStartDate,
+            const Date& accrualEndDate,
+			// RA feature
+            ext::shared_ptr<Schedule> observationsSchedule,
+			ext::shared_ptr<FxIndex> fxIndex,
+            Real lowerTrigger,
+            Real upperTrigger,
+			// optional FixedRateCoupon
+            const Date& refPeriodStart = Date(),
+            const Date& refPeriodEnd = Date(),
+            const Date& exCouponDate = Date());
+
+        FxRangeAccrualFixedCoupon(
+            // FixedRateCoupon
+            const Date& paymentDate,
+            Real nominal,
+            Real rate,
+            const DayCounter& dayCounter,
+            const Date& accrualStartDate,
+            const Date& accrualEndDate,
+            // RA feature
+            // calculate observation schedule from coupon
+            ext::shared_ptr<FxIndex> fxIndex,
+            Real lowerTrigger,
+            Real upperTrigger,
+            // optional FixedRateCoupon
+            const Date& refPeriodStart = Date(),
+            const Date& refPeriodEnd = Date(),
+            const Date& exCouponDate = Date());
+
+        //@}
+        //! \name LazyObject interface
+        //@{
+        void performCalculations() const override;
+        //@}
+        //! \name CashFlow interface
+        //@{
+        Real amount() const override;
+        //@}
+
+
+        ext::shared_ptr<Schedule> observationsSchedule() const { return observationsSchedule_; }
+        ext::shared_ptr<FxIndex> fxIndex() const { return fxIndex_; }
+        Real lowerTrigger() const { return lowerTrigger_; }
+        Real upperTrigger() const { return upperTrigger_; }
+        Real rangeAccrual() const;
+
+        //! \name Visitability
+        //@{
+        void accept(AcyclicVisitor&) override;
+        //@}
+      private:
+
+        const ext::shared_ptr<Schedule> observationsSchedule_;
+        ext::shared_ptr<FxIndex> fxIndex_;
+        std::vector<Date> observationDates_;
+        Real lowerTrigger_;
+        Real upperTrigger_;
+
+        mutable Real rangeAccrual_;
+     };
+
+
+}
+
+
+#endif

--- a/ql/indexes/Makefile.am
+++ b/ql/indexes/Makefile.am
@@ -8,6 +8,7 @@ this_include_HEADERS = \
     all.hpp \
     bmaindex.hpp \
     equityindex.hpp \
+    fxindex.hpp \
     iborindex.hpp \
     indexmanager.hpp \
     inflationindex.hpp \
@@ -18,6 +19,7 @@ this_include_HEADERS = \
 cpp_files = \
     bmaindex.cpp \
     equityindex.cpp \
+    fxindex.cpp \
     iborindex.cpp \
     indexmanager.cpp \
     inflationindex.cpp \

--- a/ql/indexes/all.hpp
+++ b/ql/indexes/all.hpp
@@ -3,6 +3,7 @@
 
 #include <ql/indexes/bmaindex.hpp>
 #include <ql/indexes/equityindex.hpp>
+#include <ql/indexes/fxindex.hpp>
 #include <ql/indexes/iborindex.hpp>
 #include <ql/indexes/indexmanager.hpp>
 #include <ql/indexes/inflationindex.hpp>

--- a/ql/indexes/fxindex.cpp
+++ b/ql/indexes/fxindex.cpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2024 Sebastian Schlenkrich
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/indexes/fxindex.hpp>
+#include <ql/settings.hpp>
+#include <utility>
+
+namespace QuantLib {
+
+    FxIndex::FxIndex(
+	    std::string name,
+        Calendar fixingCalendar,
+        Handle<YieldTermStructure> domInterest,
+        Handle<YieldTermStructure> forInterest,
+        Handle<Quote> spot
+	) : EquityIndex(std::move(name), std::move(fixingCalendar), std::move(domInterest), std::move(forInterest), std::move(spot)) {} 
+
+}

--- a/ql/indexes/fxindex.hpp
+++ b/ql/indexes/fxindex.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2024 Sebastian Schlenkrich
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file fxindex.hpp
+    \brief base class for fx indexes based on equity index
+*/
+
+#ifndef quantlib_fxindex_hpp
+#define quantlib_fxindex_hpp
+
+#include <ql/indexes/equityindex.hpp>
+
+
+namespace QuantLib {
+
+    //! Base class for FX indexes
+    /*! The FX index object allows to retrieve past fixings,
+        as well as project future fixings.
+        
+        Forward is calculated as:
+        \f[
+        I(t, T) = I(t, t) \frac{P_{F}(t, T)}{P_{D}(t, T)},
+        \f]
+        where \f$ I(t, t) \f$ is today's value of the index,
+        \f$ P_{F}(t, T) \f$ is a discount factor of the foreign
+		currency curve at future time \f$ T \f$, and
+		\f$ P_{D}(t, T) \f$ is a discount factor of the domestic
+		curve at future time \f$ T \f$.
+
+        To forecast future fixings, the user can either provide a
+        handle to the current index spot. If spot handle is empty,
+        today's fixing will be used, instead.
+    */
+    class FxIndex : public EquityIndex {
+      public:
+        FxIndex(std::string name,
+                Calendar fixingCalendar,
+                Handle<YieldTermStructure> domInterest,
+                Handle<YieldTermStructure> forInterest,
+                Handle<Quote> spot = {});
+
+        //! the domestic rate curve used to forecast fixings
+        Handle<YieldTermStructure> domesticInterestRateCurve() const {
+            return equityInterestRateCurve();
+        }
+        //! the foreign rate curve used to forecast fixings
+        Handle<YieldTermStructure> foreignInterestRateCurve() const {
+            return equityDividendCurve();
+        }
+
+    };
+
+}
+
+#endif

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -69,6 +69,7 @@ set(QL_TEST_SOURCES
     forwardoption.cpp
     forwardrateagreement.cpp
     functions.cpp
+    fxrangeaccrual.cpp
     garch.cpp
     gaussianquadratures.cpp
     gjrgarchmodel.cpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -70,6 +70,7 @@ QL_TEST_SRCS = \
 	forwardoption.cpp \
 	forwardrateagreement.cpp \
 	functions.cpp \
+	fxrangeaccrual.cpp \
 	garch.cpp \
 	gaussianquadratures.cpp \
 	gjrgarchmodel.cpp \

--- a/test-suite/fxrangeaccrual.cpp
+++ b/test-suite/fxrangeaccrual.cpp
@@ -1,0 +1,145 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2024 Sebastian Schlenkrich
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "toplevelfixture.hpp"
+#include "utilities.hpp"
+
+#include <ql/types.hpp>
+#include <ql/compounding.hpp>
+#include <ql/time/all.hpp>
+#include <ql/termstructures/yield/all.hpp>
+
+#include <ql/indexes/fxindex.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+BOOST_FIXTURE_TEST_SUITE(QuantLibTests, TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(FxRangeAccrualTests)
+
+namespace {
+    
+    Period termsData[] = {
+        Period( 0,Days),
+        Period( 1,Years),
+        Period( 2,Years),
+        Period( 3,Years),
+        Period( 5,Years),
+        Period( 7,Years),
+        Period(10,Years),
+        Period(15,Years),
+        Period(20,Years),
+        Period(61,Years)   // avoid extrapolation issues with 30y caplets
+    };
+    std::vector<Period> terms(termsData, termsData+10);
+
+    Real domDiscRatesData[] = {
+        0.0300,
+        0.0300,
+        0.0300,
+        0.0300,
+        0.0300,
+        0.0300,
+        0.0300,
+        0.0300,
+        0.0300,
+        0.0300
+    };
+    std::vector<Real> domDiscRates(domDiscRatesData, domDiscRatesData + 10);
+
+    Real forDiscRatesData[] = {
+        0.0400,
+        0.0400,
+        0.0400,
+        0.0400,
+        0.0400,
+        0.0400,
+        0.0400,
+        0.0400,
+        0.0400,
+        0.0400
+    };
+    std::vector<Real> forDiscRates(forDiscRatesData, forDiscRatesData + 10);
+
+    Handle<YieldTermStructure> getYtsh(const std::vector<Period>& terms,
+                                      const std::vector<Real>& rates,
+                                      const Real spread = 0.0) {
+        Date today = Settings::instance().evaluationDate();
+        std::vector<Date> dates;
+        dates.reserve(terms.size());
+        for (auto term : terms)
+            dates.push_back(NullCalendar().advance(today, term, Unadjusted));
+        std::vector<Real> ratesPlusSpread(rates);
+        for (double& k : ratesPlusSpread)
+            k += spread;
+        ext::shared_ptr<YieldTermStructure> ts =
+            ext::shared_ptr<YieldTermStructure>(new InterpolatedZeroCurve<Cubic>(
+                dates, ratesPlusSpread, Actual365Fixed(), NullCalendar()));
+        return RelinkableHandle<YieldTermStructure>(ts);
+    }
+
+
+} // namespace
+
+
+//******************************************************************************************//
+//******************************************************************************************//
+
+BOOST_AUTO_TEST_CASE(testCouponSetup)  {
+
+    BOOST_TEST_MESSAGE("Testing FX range accrual coupon...");
+
+    Date today = Settings::instance().evaluationDate();
+
+    BOOST_TEST_MESSAGE("Today: " << today);
+
+    Handle<YieldTermStructure> domYtsh = getYtsh(terms, domDiscRates);
+    Handle<YieldTermStructure> forYtsh = getYtsh(terms, forDiscRates);
+
+    BOOST_TEST_MESSAGE("domYtsh at today: " << domYtsh->discount(today));
+    BOOST_TEST_MESSAGE("forYtsh at today: " << forYtsh->discount(today));
+
+    RelinkableHandle<Quote> spotHandle; // = RelinkableHandle<Quote>(ext::make_shared<SimpleQuote>(0.0));
+
+    ext::shared_ptr<FxIndex> fxIndex =
+        ext::make_shared<FxIndex>(
+            "EUR-USD", TARGET(), domYtsh, forYtsh, spotHandle);
+
+    Schedule fixingSchedule =
+        Schedule(Date(1, January, 2015), Date(31, December, 2015), Period(1, Days),
+                              TARGET(), Following, Following, DateGeneration::Forward, false);
+
+    Real fx = 1.0;
+    for (auto date : fixingSchedule.dates()) {
+        fxIndex->addFixing(date, fx);
+        fx += 0.001;
+    }
+    
+    for (auto date : fixingSchedule.dates()) {
+        BOOST_TEST_MESSAGE("" << date << ": " << fxIndex->fixing(date));
+    }
+
+
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/fxrangeaccrual.cpp
+++ b/test-suite/fxrangeaccrual.cpp
@@ -29,6 +29,7 @@
 #include <ql/indexes/fxindex.hpp>
 #include <ql/cashflows/fxrangeaccrualfixed.hpp>
 
+#include <iostream>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -170,6 +171,9 @@ BOOST_AUTO_TEST_CASE(testCouponPricing)  {
 
     BOOST_TEST_MESSAGE("Testing FX range accrual coupon with pricer...");
 
+    // std::cout << "Press Enter to Continue";  // use interrupt to attach debugger
+    // std::cin.ignore();
+
     Date today = Settings::instance().evaluationDate();
 
     BOOST_TEST_MESSAGE("Today: " << today);
@@ -221,8 +225,8 @@ BOOST_AUTO_TEST_CASE(testCouponPricing)  {
 
     auto coupon = make_coupon(1.10, 1.175);
 
-    for (auto date : coupon.observationsSchedule()->dates()) {
-        BOOST_TEST_MESSAGE("ObsDate: " << date << ", Index: " << fxIndex->fixing(date));
+    for (Date date : coupon.observationsSchedule()->dates()) {
+        BOOST_TEST_MESSAGE("ObsDate: " << io::iso_date(date) << ", Index: " << fxIndex->fixing(date));
     }
 
     std::vector<FxRangeAccrualFixedCoupon> cps;
@@ -235,8 +239,98 @@ BOOST_AUTO_TEST_CASE(testCouponPricing)  {
         cp.setPricer(pricer);
     }
 
-    for (auto cp : cps) {
+    BOOST_TEST_MESSAGE("Coupon Results:");
+    for (FxRangeAccrualFixedCoupon& cp : cps) {
         BOOST_TEST_MESSAGE("Rate: " << cp.rate() << ", RA: " << cp.rangeAccrual() << ", Amount: " << cp.amount());
+    }
+
+    BOOST_TEST_MESSAGE("Additional Results 4th coupon:");
+    auto additionalResults = cps[3].additionalResults();
+    for (auto const& x : additionalResults) {
+        std::cout << x.first << " : " << x.second << std::endl;
+    }
+}
+
+
+
+BOOST_AUTO_TEST_CASE(testCouponLeg) {
+
+    BOOST_TEST_MESSAGE("Testing FX range accrual coupon leg with pricer...");
+
+    // std::cout << "Press Enter to Continue";  // use interrupt to attach debugger
+    // std::cin.ignore();
+
+    Date today = Settings::instance().evaluationDate();
+
+    BOOST_TEST_MESSAGE("Today: " << today);
+
+    Handle<YieldTermStructure> domYtsh = getYtsh(terms, domDiscRates);
+    Handle<YieldTermStructure> forYtsh = getYtsh(terms, forDiscRates);
+
+    BOOST_TEST_MESSAGE("domYtsh at today: " << domYtsh->discount(today));
+    BOOST_TEST_MESSAGE("forYtsh at today: " << forYtsh->discount(today));
+
+    RelinkableHandle<Quote>
+        spotHandle; // = RelinkableHandle<Quote>(ext::make_shared<SimpleQuote>(0.0));
+
+    ext::shared_ptr<FxIndex> fxIndex =
+        ext::make_shared<FxIndex>("EUR-USD", TARGET(), domYtsh, forYtsh, spotHandle);
+
+    Schedule fixingSchedule =
+        Schedule(Date(1, January, 2015), Date(31, December, 2015), Period(1, Days), TARGET(),
+                 Following, Following, DateGeneration::Forward, false);
+
+    Real fx = 1.0;
+    for (auto date : fixingSchedule.dates()) {
+        fxIndex->addFixing(date, fx);
+        fx += 0.001;
+    }
+
+
+    RelinkableHandle<Quote> volQuote = RelinkableHandle<Quote>(ext::make_shared<SimpleQuote>(0.25));
+    ext::shared_ptr<BlackVolTermStructure> volTs = ext::shared_ptr<BlackVolTermStructure>(
+        new BlackConstantVol(today, TARGET(), volQuote, Actual365Fixed()));
+    RelinkableHandle<BlackVolTermStructure> volTsh(volTs);
+    ext::shared_ptr<FxRangeAccrualFixedCouponPricer> pricer =
+        ext::make_shared<FxRangeAccrualFixedCouponPricer>(volTsh);
+
+
+    auto startDate = Date(15, January, 2015);
+    auto endDate = Date(15, January, 2045);
+    auto period = Period(3, Months);
+    auto cal = TARGET();
+    auto endOfMonth = false;
+    Schedule couponSchedule = Schedule(startDate, endDate, period, cal, Following, Following,
+                                       DateGeneration::Backward, endOfMonth);
+
+    Real notional = 100.0;
+    Real fixedRate = 0.01;
+    auto dc = Actual360();
+
+    auto lowerTrigger = 1.10;
+    auto upperTrigger = 1.20;
+
+    std::vector<FxRangeAccrualFixedCoupon> leg;
+    for (Size k = 0; k < couponSchedule.dates().size()-1; ++k) {
+        auto startDate = couponSchedule.dates()[k];
+        auto endDate = couponSchedule.dates()[k+1];
+        auto payDate = couponSchedule.dates()[k + 1];
+        leg.push_back(FxRangeAccrualFixedCoupon(payDate, notional, fixedRate, dc, startDate,
+                                                endDate, fxIndex, lowerTrigger, upperTrigger)
+        );
+    }
+
+    for (FxRangeAccrualFixedCoupon& cp : leg) { // make sure we get a reference and not a copy
+        cp.setPricer(pricer);
+    }
+
+    BOOST_TEST_MESSAGE("Coupon Results:");
+    for (FxRangeAccrualFixedCoupon& cp : leg) {
+        BOOST_TEST_MESSAGE("Start: " << io::iso_date(cp.accrualStartDate())
+                                     << ", End: " << io::iso_date(cp.accrualEndDate())
+                                     << ", RA: " << cp.rangeAccrual()
+                                     << ", Rate: " << cp.rate()
+                                    << ", Amount: " << cp.amount());
     }
 }
 

--- a/test-suite/fxrangeaccrual.cpp
+++ b/test-suite/fxrangeaccrual.cpp
@@ -24,6 +24,7 @@
 #include <ql/compounding.hpp>
 #include <ql/time/all.hpp>
 #include <ql/termstructures/yield/all.hpp>
+#include <ql/termstructures/volatility/all.hpp>
 
 #include <ql/indexes/fxindex.hpp>
 #include <ql/cashflows/fxrangeaccrualfixed.hpp>
@@ -106,7 +107,7 @@ namespace {
 
 BOOST_AUTO_TEST_CASE(testCouponSetup)  {
 
-    BOOST_TEST_MESSAGE("Testing FX range accrual coupon...");
+    BOOST_TEST_MESSAGE("Testing FX range accrual coupon without pricer...");
 
     Date today = Settings::instance().evaluationDate();
 
@@ -133,7 +134,7 @@ BOOST_AUTO_TEST_CASE(testCouponSetup)  {
         fxIndex->addFixing(date, fx);
         fx += 0.001;
     }
-    
+
     auto startDate = Date(31, August, 2015);
     auto endDate = Date(30, September, 2015);
     auto payDate = Date(30, September, 2015);
@@ -163,6 +164,82 @@ BOOST_AUTO_TEST_CASE(testCouponSetup)  {
         BOOST_TEST_MESSAGE("Rate: " << cp.rate() << ", RA: " << cp.rangeAccrual() << ", Amount: " << cp.amount());
     }
 }
+
+
+BOOST_AUTO_TEST_CASE(testCouponPricing)  {
+
+    BOOST_TEST_MESSAGE("Testing FX range accrual coupon with pricer...");
+
+    Date today = Settings::instance().evaluationDate();
+
+    BOOST_TEST_MESSAGE("Today: " << today);
+
+    Handle<YieldTermStructure> domYtsh = getYtsh(terms, domDiscRates);
+    Handle<YieldTermStructure> forYtsh = getYtsh(terms, forDiscRates);
+
+    BOOST_TEST_MESSAGE("domYtsh at today: " << domYtsh->discount(today));
+    BOOST_TEST_MESSAGE("forYtsh at today: " << forYtsh->discount(today));
+
+    RelinkableHandle<Quote> spotHandle; // = RelinkableHandle<Quote>(ext::make_shared<SimpleQuote>(0.0));
+
+    ext::shared_ptr<FxIndex> fxIndex =
+        ext::make_shared<FxIndex>(
+            "EUR-USD", TARGET(), domYtsh, forYtsh, spotHandle);
+
+    Schedule fixingSchedule =
+        Schedule(Date(1, January, 2015), Date(31, December, 2015), Period(1, Days),
+                              TARGET(), Following, Following, DateGeneration::Forward, false);
+
+    Real fx = 1.0;
+    for (auto date : fixingSchedule.dates()) {
+        fxIndex->addFixing(date, fx);
+        fx += 0.001;
+    }
+
+
+    RelinkableHandle<Quote> volQuote = RelinkableHandle<Quote>(ext::make_shared<SimpleQuote>(0.25));
+    ext::shared_ptr<BlackVolTermStructure> volTs = ext::shared_ptr<BlackVolTermStructure>(
+        new BlackConstantVol(today, TARGET(), volQuote, Actual365Fixed())
+    );
+    RelinkableHandle<BlackVolTermStructure> volTsh(volTs);
+    ext::shared_ptr<FxRangeAccrualFixedCouponPricer> pricer =
+        ext::make_shared<FxRangeAccrualFixedCouponPricer>(volTsh);
+
+
+    auto startDate = Date(31, August, 2015);
+    auto endDate = Date(30, September, 2015);
+    auto payDate = Date(30, September, 2015);
+    Real notional = 100.0;
+    Real fixedRate = 0.01;
+    auto dc = Actual360();
+
+    auto make_coupon = [payDate, notional, fixedRate, dc, startDate, endDate,
+                        fxIndex](Real lowerTrigger, Real upperTrigger) {
+        return FxRangeAccrualFixedCoupon(payDate, notional, fixedRate, dc, startDate, endDate,
+                                         fxIndex, lowerTrigger, upperTrigger);
+    };
+
+    auto coupon = make_coupon(1.10, 1.175);
+
+    for (auto date : coupon.observationsSchedule()->dates()) {
+        BOOST_TEST_MESSAGE("ObsDate: " << date << ", Index: " << fxIndex->fixing(date));
+    }
+
+    std::vector<FxRangeAccrualFixedCoupon> cps;
+    cps.push_back(make_coupon(1.10, 1.15));
+    cps.push_back(make_coupon(1.15, 1.20));
+    cps.push_back(make_coupon(1.20, 1.22));
+    cps.push_back(make_coupon(1.15, 1.175));  // RA 8/23 = 0.347826087
+
+    for (auto cp : cps) {
+        cp.setPricer(pricer);
+    }
+
+    for (auto cp : cps) {
+        BOOST_TEST_MESSAGE("Rate: " << cp.rate() << ", RA: " << cp.rangeAccrual() << ", Amount: " << cp.amount());
+    }
+}
+
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/fxrangeaccrual.cpp
+++ b/test-suite/fxrangeaccrual.cpp
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(testCouponPricing)  {
     cps.push_back(make_coupon(1.20, 1.22));
     cps.push_back(make_coupon(1.15, 1.175));  // RA 8/23 = 0.347826087
 
-    for (auto cp : cps) {
+    for (FxRangeAccrualFixedCoupon& cp : cps) { // make sure we get a reference and not a copy
         cp.setPricer(pricer);
     }
 

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -706,6 +706,7 @@
     <ClCompile Include="fdmlinearop.cpp" />
     <ClCompile Include="forwardoption.cpp" />
     <ClCompile Include="forwardrateagreement.cpp" />
+    <ClCompile Include="fxrangeaccrual.cpp" />
     <ClCompile Include="garch.cpp" />
     <ClCompile Include="gaussianquadratures.cpp" />
     <ClCompile Include="gjrgarchmodel.cpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -531,6 +531,9 @@
     <ClCompile Include="equitycashflow.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="fxrangeaccrual.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="paralleltestrunner.hpp">


### PR DESCRIPTION
This PR adds new `FxIndex` and `FxRangeAccrualFixedCoupon` classes.

Initial valuation methodology is based on intrinsic value calculation for the range accrual feature.

Next step is to add a Black model based `CouponPricer`.