### PR TITLE
Add CMS RA coupon, pricer and tests

### DIFF
--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -6,6 +6,7 @@ set(QL_SOURCES
     cashflows/cashflows.cpp
     cashflows/cashflowvectors.cpp
     cashflows/cmscoupon.cpp
+    cashflows/cmsrangeaccrualfixed.cpp
     cashflows/conundrumpricer.cpp
     cashflows/coupon.cpp
     cashflows/couponpricer.cpp
@@ -945,6 +946,7 @@ set(QL_HEADERS
     cashflows/cashflows.hpp
     cashflows/cashflowvectors.hpp
     cashflows/cmscoupon.hpp
+    cashflows/cmsrangeaccrualfixed.hpp
     cashflows/conundrumpricer.hpp
     cashflows/coupon.hpp
     cashflows/couponpricer.hpp

--- a/ql/cashflows/Makefile.am
+++ b/ql/cashflows/Makefile.am
@@ -10,6 +10,7 @@ this_include_HEADERS = \
     cashflows.hpp \
     cashflowvectors.hpp \
     cmscoupon.hpp \
+    cmsrangeaccrualfixed.hpp \
     conundrumpricer.hpp \
     coupon.hpp \
     couponpricer.hpp \
@@ -46,6 +47,7 @@ cpp_files = \
     cashflows.cpp \
     cashflowvectors.cpp \
     cmscoupon.cpp \
+    cmsrangeaccrualfixed.cpp \
     conundrumpricer.cpp \
     coupon.cpp \
     couponpricer.cpp \

--- a/ql/cashflows/all.hpp
+++ b/ql/cashflows/all.hpp
@@ -7,6 +7,7 @@
 #include <ql/cashflows/cashflows.hpp>
 #include <ql/cashflows/cashflowvectors.hpp>
 #include <ql/cashflows/cmscoupon.hpp>
+#include <ql/cashflows/cmsrangeaccrualfixed.hpp>
 #include <ql/cashflows/conundrumpricer.hpp>
 #include <ql/cashflows/coupon.hpp>
 #include <ql/cashflows/couponpricer.hpp>

--- a/ql/cashflows/cmsrangeaccrualfixed.cpp
+++ b/ql/cashflows/cmsrangeaccrualfixed.cpp
@@ -1,0 +1,210 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2006, 2007 Giorgio Facchinetti
+ Copyright (C) 2006, 2007 Mario Pucci
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/patterns/visitor.hpp>
+#include <ql/patterns/lazyobject.hpp>
+
+#include <ql/cashflows/cashflowvectors.hpp>
+#include <ql/cashflows/cmsrangeaccrualfixed.hpp>
+#include <ql/indexes/swapindex.hpp>
+#include <ql/math/distributions/normaldistribution.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/termstructures/volatility/swaption/swaptionvolstructure.hpp>
+#include <ql/time/schedule.hpp>
+#include <cmath>
+#include <utility>
+
+namespace QuantLib {
+
+    CmsRangeAccrualFixedCoupon::CmsRangeAccrualFixedCoupon(
+        // FixedRateCoupon
+        const Date& paymentDate,
+        Real nominal,
+        Real rate,
+        const DayCounter& dayCounter,
+        const Date& accrualStartDate,
+        const Date& accrualEndDate,
+        // RA feature
+        ext::shared_ptr<Schedule> observationsSchedule,
+        ext::shared_ptr<SwapIndex> cmsIndex,
+        Real lowerTrigger,
+        Real upperTrigger,
+        // optional FixedRateCoupon
+        const Date& refPeriodStart,
+        const Date& refPeriodEnd,
+        const Date& exCouponDate)
+    : FixedRateCoupon(paymentDate,
+                      nominal,
+                      rate,
+                      dayCounter,
+                      accrualStartDate,
+                      accrualEndDate,
+                      refPeriodStart,
+                      refPeriodEnd,
+                      exCouponDate),
+      observationsSchedule_(std::move(observationsSchedule)), cmsIndex_(std::move(cmsIndex)),
+      lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), pricer_(0), rangeAccrual_(0.0) {
+        QL_REQUIRE(observationsSchedule_, "observationsSchedule_ required.");
+        QL_REQUIRE(cmsIndex_, "cmsIndex_ required.");
+        QL_REQUIRE(lowerTrigger_ > 0.0, "lowerTrigger_ > 0.0 required.");
+        QL_REQUIRE(lowerTrigger_ < upperTrigger_, "lowerTrigger_ < upperTrigger_ required.");
+    }
+
+
+    CmsRangeAccrualFixedCoupon::CmsRangeAccrualFixedCoupon(
+        // FixedRateCoupon
+        const Date& paymentDate,
+        Real nominal,
+        Real rate,
+        const DayCounter& dayCounter,
+        const Date& accrualStartDate,
+        const Date& accrualEndDate,
+        // RA feature
+        // calculate observation schedule from coupon
+        ext::shared_ptr<SwapIndex> cmsIndex,
+        Real lowerTrigger,
+        Real upperTrigger,
+        // optional FixedRateCoupon
+        const Date& refPeriodStart,
+        const Date& refPeriodEnd,
+        const Date& exCouponDate)
+    : FixedRateCoupon(paymentDate,
+                      nominal,
+                      rate,
+                      dayCounter,
+                      accrualStartDate,
+                      accrualEndDate,
+                      refPeriodStart,
+                      refPeriodEnd,
+                      exCouponDate),
+    observationsSchedule_(ext::make_shared<Schedule>(MakeSchedule()
+                                    .from(accrualStartDate)
+                                    .to(accrualEndDate)
+                                    .withFrequency(Daily)
+                                    .withCalendar(cmsIndex->fixingCalendar())
+                                    .withConvention(Following))),
+    cmsIndex_(std::move(cmsIndex)),
+    lowerTrigger_(lowerTrigger), upperTrigger_(upperTrigger), pricer_(0), rangeAccrual_(0.0) {
+        QL_REQUIRE(observationsSchedule_, "observationsSchedule_ required.");
+        QL_REQUIRE(cmsIndex_, "cmsIndex_ required.");
+        QL_REQUIRE(lowerTrigger_ < upperTrigger_, "lowerTrigger_ < upperTrigger_ required.");
+    }
+
+
+    void CmsRangeAccrualFixedCoupon::performCalculations() const {
+        FixedRateCoupon::performCalculations();
+        if (pricer_) {
+            pricer_->initialize(*this);
+            rangeAccrual_ = pricer_->rangeAccrual();
+            additionalResults_ = pricer_->additionalResults();
+        } else {
+            // calculate fall-back via intrinsic value
+            Real inRange = 0.0;
+            for (auto d : observationsSchedule()->dates()) {
+                auto indexObservation = cmsIndex()->fixing(d);
+                if (indexObservation >= lowerTrigger() && indexObservation <= upperTrigger())
+                    inRange += 1.0;
+            }
+            rangeAccrual_ = inRange / observationsSchedule()->dates().size();
+        }
+    }
+
+    Real CmsRangeAccrualFixedCoupon::rangeAccrual() const {
+        calculate();  // make sure member is calculated
+        return rangeAccrual_;
+    }
+
+
+    Real CmsRangeAccrualFixedCoupon::amount() const {
+        calculate();
+        return rangeAccrual_ * FixedRateCoupon::amount();
+    }
+
+
+    void CmsRangeAccrualFixedCoupon::accept(AcyclicVisitor& v) {
+        auto* v1 = dynamic_cast<Visitor<CmsRangeAccrualFixedCoupon>*>(&v);
+        if (v1 != nullptr)
+            v1->visit(*this);
+        else
+            FixedRateCoupon::accept(v);
+    }
+
+    void CmsRangeAccrualFixedCoupon::setPricer(
+        const ext::shared_ptr<CmsRangeAccrualFixedCouponPricer>& pricer) {
+        if (pricer_ != nullptr)
+            unregisterWith(pricer_);
+        pricer_ = pricer;
+        if (pricer_ != nullptr)
+            registerWith(pricer_);
+        update();
+    }
+
+    CmsRangeAccrualFixedCouponPricer::CmsRangeAccrualFixedCouponPricer(
+        Handle<SwaptionVolatilityStructure> swaptionVolatility)
+    : swaptionVolatility_(swaptionVolatility), rangeAccrual_(Null<Real>()) {}
+
+    void CmsRangeAccrualFixedCouponPricer::initialize(const CmsRangeAccrualFixedCoupon& coupon) {
+        additionalResults_.clear();
+        Period swapTerm = coupon.cmsIndex()->tenor();
+        // implement rangeAccrual_ calculation...
+        Real minStd = 0.000005;  // 1bp * sqrt(1d)
+        CumulativeNormalDistribution Phi;
+        Real daysInRange = 0.0;
+        for (auto d : coupon.observationsSchedule()->dates()) {
+            std::ostringstream s;
+            s << io::iso_date(d);
+            std::string date_s = s.str();
+            Real indexObservation = coupon.cmsIndex()->fixing(d);
+            Real standardDevLow = 0.0;
+            Real standardDevUpp = 0.0;
+            if (d > swaptionVolatility_->referenceDate()) {
+                standardDevLow = std::sqrt(std::max(swaptionVolatility_->blackVariance(d, swapTerm, coupon.lowerTrigger(), true), 0.0));
+                standardDevUpp = std::sqrt(std::max(swaptionVolatility_->blackVariance(d, swapTerm, coupon.upperTrigger(), true), 0.0));
+            }
+            Real inRangeProbability = 0.0;
+            if (standardDevLow < minStd) {  // calculate intrinsic value
+                if (indexObservation >= coupon.lowerTrigger() &&
+                    indexObservation <= coupon.upperTrigger())
+                    inRangeProbability = 1.0;
+            } else {  // put option spread valuation
+                // Adjust for convexity adjustment
+                Real hLower = (coupon.lowerTrigger() - indexObservation) / standardDevLow;
+                Real hUpper = (coupon.upperTrigger() - indexObservation) / standardDevUpp;
+                Real putLower = Phi(hLower);
+                Real putUpper = Phi(hUpper);
+                inRangeProbability = putUpper - putLower;
+            }
+            daysInRange += inRangeProbability;
+            //
+            additionalResults_["indexObservation_" + date_s] = indexObservation;
+            additionalResults_["standardDevLow_" + date_s] = standardDevLow;
+            additionalResults_["standardDevUpp_" + date_s] = standardDevUpp;
+            additionalResults_["inRangeProbability_" + date_s] = inRangeProbability;
+        }
+        rangeAccrual_ = daysInRange / coupon.observationsSchedule()->dates().size();
+        additionalResults_["daysInRange"] = daysInRange;
+        additionalResults_["observationDays"] = (Real) coupon.observationsSchedule()->dates().size();
+    }
+
+    Real CmsRangeAccrualFixedCouponPricer::rangeAccrual() const {
+        return rangeAccrual_;
+    }
+
+}

--- a/ql/cashflows/cmsrangeaccrualfixed.hpp
+++ b/ql/cashflows/cmsrangeaccrualfixed.hpp
@@ -1,0 +1,148 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+
+ Copyright (C) 2006, 2007 Giorgio Facchinetti
+ Copyright (C) 2006, 2007 Mario Pucci
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file rangeaccrual.hpp
+    \brief range-accrual coupon
+*/
+
+#ifndef quantlib_cms_range_accrual_fixed_h
+#define quantlib_cms_range_accrual_fixed_h
+
+#include <ql/cashflows/couponpricer.hpp>
+#include <ql/cashflows/fixedratecoupon.hpp>
+#include <ql/time/schedule.hpp>
+#include <vector>
+
+namespace QuantLib {
+
+    class SwapIndex;
+    class SwaptionVolatilityStructure;
+    class CmsRangeAccrualFixedCouponPricer;
+
+    class CmsRangeAccrualFixedCoupon: public FixedRateCoupon {
+
+      public:
+        CmsRangeAccrualFixedCoupon(
+		    // FixedRateCoupon
+		    const Date& paymentDate,
+            Real nominal,
+            Real rate,
+            const DayCounter& dayCounter,
+            const Date& accrualStartDate,
+            const Date& accrualEndDate,
+			// RA feature
+            ext::shared_ptr<Schedule> observationsSchedule,
+			ext::shared_ptr<SwapIndex> cmsIndex,
+            Real lowerTrigger,
+            Real upperTrigger,
+			// optional FixedRateCoupon
+            const Date& refPeriodStart = Date(),
+            const Date& refPeriodEnd = Date(),
+            const Date& exCouponDate = Date());
+
+        CmsRangeAccrualFixedCoupon(
+            // FixedRateCoupon
+            const Date& paymentDate,
+            Real nominal,
+            Real rate,
+            const DayCounter& dayCounter,
+            const Date& accrualStartDate,
+            const Date& accrualEndDate,
+            // RA feature
+            // calculate observation schedule from coupon
+            ext::shared_ptr<SwapIndex> cmsIndex,
+            Real lowerTrigger,
+            Real upperTrigger,
+            // optional FixedRateCoupon
+            const Date& refPeriodStart = Date(),
+            const Date& refPeriodEnd = Date(),
+            const Date& exCouponDate = Date());
+
+        //@}
+        //! \name LazyObject interface
+        //@{
+        void performCalculations() const override;
+        //@}
+        //! \name CashFlow interface
+        //@{
+        Real amount() const override;
+        //@}
+
+
+        ext::shared_ptr<Schedule> observationsSchedule() const { return observationsSchedule_; }
+        ext::shared_ptr<SwapIndex> cmsIndex() const { return cmsIndex_; }
+        Real lowerTrigger() const { return lowerTrigger_; }
+        Real upperTrigger() const { return upperTrigger_; }
+        Real rangeAccrual() const;
+
+        //! \name Visitability
+        //@{
+        void accept(AcyclicVisitor&) override;
+        //@}
+
+        void setPricer(const ext::shared_ptr<CmsRangeAccrualFixedCouponPricer>&);
+
+        std::map<std::string, Real>& additionalResults() const { return additionalResults_; }
+
+      private:
+
+        const ext::shared_ptr<Schedule> observationsSchedule_;
+        ext::shared_ptr<SwapIndex> cmsIndex_;
+        std::vector<Date> observationDates_;
+        Real lowerTrigger_;
+        Real upperTrigger_;
+
+        ext::shared_ptr<CmsRangeAccrualFixedCouponPricer> pricer_;
+        mutable Real rangeAccrual_;
+        mutable std::map<std::string, Real> additionalResults_;
+     };
+
+
+    class CmsRangeAccrualFixedCouponPricer
+    : public virtual Observer,
+      public virtual Observable {
+      public:
+
+        CmsRangeAccrualFixedCouponPricer(
+            Handle<SwaptionVolatilityStructure> swaptionVolatility
+        );
+
+        void initialize(const CmsRangeAccrualFixedCoupon& coupon);
+
+        Real rangeAccrual() const;
+
+        std::map<std::string, Real>& additionalResults() const { return additionalResults_; }
+
+      //! \name Observer interface
+      //@{
+      void update() override { notifyObservers(); }
+      //@}
+
+      protected:
+        Handle<SwaptionVolatilityStructure> swaptionVolatility_;
+        Real rangeAccrual_;
+        mutable std::map<std::string, Real> additionalResults_;
+    };
+
+}
+
+
+#endif

--- a/test-suite/cmsrangeaccrual.cpp
+++ b/test-suite/cmsrangeaccrual.cpp
@@ -1,0 +1,344 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2024 Sebastian Schlenkrich
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "toplevelfixture.hpp"
+#include "utilities.hpp"
+
+#include <ql/types.hpp>
+#include <ql/compounding.hpp>
+#include <ql/time/all.hpp>
+#include <ql/termstructures/yield/all.hpp>
+#include <ql/termstructures/volatility/all.hpp>
+
+#include <ql/indexes/all.hpp>
+#include <ql/cashflows/cmsrangeaccrualfixed.hpp>
+
+#include <iostream>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+BOOST_FIXTURE_TEST_SUITE(QuantLibTests, TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(CmsRangeAccrualTests)
+
+namespace {
+    
+    Period termsData[] = {
+        Period( 0,Days),
+        Period( 1,Years),
+        Period( 2,Years),
+        Period( 3,Years),
+        Period( 5,Years),
+        Period( 7,Years),
+        Period(10,Years),
+        Period(15,Years),
+        Period(20,Years),
+        Period(61,Years)   // avoid extrapolation issues with 30y caplets
+    };
+    std::vector<Period> terms(termsData, termsData+10);
+
+    Real discRatesData[] = {
+        0.0250,
+        0.0250,
+        0.0250,
+        0.0250,
+        0.0250,
+        0.0250,
+        0.0250,
+        0.0250,
+        0.0250,
+        0.0250
+    };
+    std::vector<Real> discRates(discRatesData, discRatesData + 10);
+
+    Real projRatesData[] = {
+        0.0280,
+        0.0280,
+        0.0280,
+        0.0280,
+        0.0280,
+        0.0280,
+        0.0280,
+        0.0300,
+        0.0400,
+        0.0400
+    };
+    std::vector<Real> projRates(projRatesData, projRatesData + 10);
+
+    Handle<YieldTermStructure> getYtsh(const std::vector<Period>& terms,
+                                      const std::vector<Real>& rates,
+                                      const Real spread = 0.0) {
+        Date today = Settings::instance().evaluationDate();
+        std::vector<Date> dates;
+        dates.reserve(terms.size());
+        for (auto term : terms)
+            dates.push_back(NullCalendar().advance(today, term, Unadjusted));
+        std::vector<Real> ratesPlusSpread(rates);
+        for (double& k : ratesPlusSpread)
+            k += spread;
+        ext::shared_ptr<YieldTermStructure> ts =
+            ext::shared_ptr<YieldTermStructure>(new InterpolatedZeroCurve<Cubic>(
+                dates, ratesPlusSpread, Actual365Fixed(), NullCalendar()));
+        return RelinkableHandle<YieldTermStructure>(ts);
+    }
+
+
+} // namespace
+
+
+//******************************************************************************************//
+//******************************************************************************************//
+
+BOOST_AUTO_TEST_CASE(testCouponSetup)  {
+
+    BOOST_TEST_MESSAGE("Testing CMS range accrual coupon without pricer...");
+
+    Date today = Settings::instance().evaluationDate();
+
+    BOOST_TEST_MESSAGE("Today: " << today);
+
+    Handle<YieldTermStructure> discYtsh = getYtsh(terms, discRates);
+    Handle<YieldTermStructure> projYtsh = getYtsh(terms, projRates);
+
+    BOOST_TEST_MESSAGE("discYtsh at today: " << discYtsh->discount(today));
+    BOOST_TEST_MESSAGE("projYtsh at today: " << projYtsh->discount(today));
+
+    ext::shared_ptr<SwapIndex> swapIndex =
+        ext::make_shared<EuriborSwapIsdaFixA>(Period(10, Years), projYtsh, discYtsh);
+
+    Schedule fixingSchedule =
+        Schedule(Date(1, January, 2015), Date(31, December, 2015), Period(1, Days),
+                              TARGET(), Following, Following, DateGeneration::Forward, false);
+
+    Real swapRate = 0.0100;
+    for (auto date : fixingSchedule.dates()) {
+        swapIndex->addFixing(date, swapRate);
+        swapRate += 0.0001;
+    }
+
+    auto startDate = Date(31, August, 2015);
+    auto endDate = Date(30, September, 2015);
+    auto payDate = Date(30, September, 2015);
+    Real notional = 100.0;
+    Real fixedRate = 0.01;
+    auto dc = Actual360();
+
+    auto make_coupon = [payDate, notional, fixedRate, dc, startDate, endDate,
+                        swapIndex](Real lowerTrigger, Real upperTrigger) {
+        return CmsRangeAccrualFixedCoupon(payDate, notional, fixedRate, dc, startDate, endDate,
+                                         swapIndex, lowerTrigger, upperTrigger);
+    };
+
+    auto coupon = make_coupon(0.0100, 0.0300);
+
+    for (auto date : coupon.observationsSchedule()->dates()) {
+        BOOST_TEST_MESSAGE("ObsDate: " << date << ", Index: " << swapIndex->fixing(date));
+    }
+
+    std::vector<CmsRangeAccrualFixedCoupon> cps;
+    cps.push_back(make_coupon(0.0250, 0.0260));  // RA 0
+    cps.push_back(make_coupon(0.0260, 0.0275));  // RA 8/23
+    cps.push_back(make_coupon(0.0275, 0.0280));  // RA 5/23
+    cps.push_back(make_coupon(0.0280, 0.0290));  // RA 10/23
+    cps.push_back(make_coupon(0.0290, 0.0300));  // RA 0
+    
+    for (auto cp : cps) {
+        BOOST_TEST_MESSAGE("Rate: " << cp.rate() << ", RA: " << cp.rangeAccrual() << ", Amount: " << cp.amount());
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(testCouponPricing)  {
+
+    BOOST_TEST_MESSAGE("Testing CMS range accrual coupon with pricer...");
+
+    // std::cout << "Press Enter to Continue";  // use interrupt to attach debugger
+    // std::cin.ignore();
+
+    Date today = Settings::instance().evaluationDate();
+
+    BOOST_TEST_MESSAGE("Today: " << today);
+
+    Handle<YieldTermStructure> discYtsh = getYtsh(terms, discRates);
+    Handle<YieldTermStructure> projYtsh = getYtsh(terms, projRates);
+
+    BOOST_TEST_MESSAGE("discYtsh at today: " << discYtsh->discount(today));
+    BOOST_TEST_MESSAGE("projYtsh at today: " << projYtsh->discount(today));
+
+
+    ext::shared_ptr<SwapIndex> swapIndex =
+        ext::make_shared<EuriborSwapIsdaFixA>(Period(10, Years), projYtsh, discYtsh);
+
+    Schedule fixingSchedule =
+        Schedule(Date(1, January, 2015), Date(31, December, 2015), Period(1, Days),
+                              TARGET(), Following, Following, DateGeneration::Forward, false);
+
+    Real swapRate = 0.0100;
+    for (auto date : fixingSchedule.dates()) {
+        swapIndex->addFixing(date, swapRate);
+        swapRate += 0.0001;
+    }
+
+
+    RelinkableHandle<Quote> volQuote = RelinkableHandle<Quote>(ext::make_shared<SimpleQuote>(0.0050));
+    VolatilityType vType = Normal;
+    //
+    ext::shared_ptr<SwaptionVolatilityStructure> volTs =
+        ext::shared_ptr<ConstantSwaptionVolatility>(
+            new ConstantSwaptionVolatility(
+                today, TARGET(), Following, volQuote, Actual365Fixed(), vType)
+    );
+    RelinkableHandle<SwaptionVolatilityStructure> volTsh(volTs);
+    //
+    ext::shared_ptr<CmsRangeAccrualFixedCouponPricer> pricer =
+        ext::make_shared<CmsRangeAccrualFixedCouponPricer>(volTsh);
+
+    auto startDate = Date(31, August, 2015);
+    auto endDate = Date(30, September, 2015);
+    auto payDate = Date(30, September, 2015);
+    Real notional = 100.0;
+    Real fixedRate = 0.01;
+    auto dc = Actual360();
+    
+    auto make_coupon = [payDate, notional, fixedRate, dc, startDate, endDate,
+                        swapIndex](Real lowerTrigger, Real upperTrigger) {
+        return CmsRangeAccrualFixedCoupon(payDate, notional, fixedRate, dc, startDate, endDate,
+                                         swapIndex, lowerTrigger, upperTrigger);
+    };
+    
+    auto coupon = make_coupon(0.0100, 0.0300);
+    
+    for (Date date : coupon.observationsSchedule()->dates()) {
+        BOOST_TEST_MESSAGE("ObsDate: " << io::iso_date(date) << ", Index: " << swapIndex->fixing(date));
+    }
+    
+    std::vector<CmsRangeAccrualFixedCoupon> cps;
+    cps.push_back(make_coupon(0.0000, 0.0250)); // RA 0
+    cps.push_back(make_coupon(0.0250, 0.0260)); // RA 0
+    cps.push_back(make_coupon(0.0260, 0.0275)); // RA 8/23
+    cps.push_back(make_coupon(0.0275, 0.0280)); // RA 5/23
+    cps.push_back(make_coupon(0.0280, 0.0290)); // RA 10/23
+    cps.push_back(make_coupon(0.0290, 0.0300)); // RA 0
+    cps.push_back(make_coupon(0.0300, 0.0600)); // RA 0
+    
+    for (CmsRangeAccrualFixedCoupon& cp : cps) { // make sure we get a reference and not a copy
+        cp.setPricer(pricer);
+    }
+    
+    BOOST_TEST_MESSAGE("Coupon Results:");
+    for (CmsRangeAccrualFixedCoupon& cp : cps) {
+        BOOST_TEST_MESSAGE("Rate: " << cp.rate() << ", RA: " << cp.rangeAccrual() << ", Amount: " << cp.amount());
+    }
+    
+    BOOST_TEST_MESSAGE("Additional Results 5th coupon:");
+    auto additionalResults = cps[4].additionalResults();
+    for (auto const& x : additionalResults) {
+        std::cout << x.first << " : " << x.second << std::endl;
+    }
+}
+
+
+
+BOOST_AUTO_TEST_CASE(testCouponLeg) {
+
+    BOOST_TEST_MESSAGE("Testing CMS range accrual coupon leg with pricer...");
+
+    // std::cout << "Press Enter to Continue";  // use interrupt to attach debugger
+    // std::cin.ignore();
+
+    Date today = Settings::instance().evaluationDate();
+
+    BOOST_TEST_MESSAGE("Today: " << today);
+
+    Handle<YieldTermStructure> discYtsh = getYtsh(terms, discRates);
+    Handle<YieldTermStructure> projYtsh = getYtsh(terms, projRates);
+
+    BOOST_TEST_MESSAGE("discYtsh at today: " << discYtsh->discount(today));
+    BOOST_TEST_MESSAGE("projYtsh at today: " << projYtsh->discount(today));
+
+    ext::shared_ptr<SwapIndex> swapIndex =
+        ext::make_shared<EuriborSwapIsdaFixA>(Period(10, Years), projYtsh, discYtsh);
+
+    Schedule fixingSchedule =
+        Schedule(Date(1, January, 2015), Date(31, December, 2015), Period(1, Days), TARGET(),
+                 Following, Following, DateGeneration::Forward, false);
+
+    Real swapRate = 0.0100;
+    for (auto date : fixingSchedule.dates()) {
+        swapIndex->addFixing(date, swapRate);
+        swapRate += 0.0001;
+    }
+
+    RelinkableHandle<Quote> volQuote =
+        RelinkableHandle<Quote>(ext::make_shared<SimpleQuote>(0.0050));
+    VolatilityType vType = Normal;
+    //
+    ext::shared_ptr<SwaptionVolatilityStructure> volTs =
+        ext::shared_ptr<ConstantSwaptionVolatility>(new ConstantSwaptionVolatility(
+            today, TARGET(), Following, volQuote, Actual365Fixed(), vType));
+    RelinkableHandle<SwaptionVolatilityStructure> volTsh(volTs);
+    //
+    ext::shared_ptr<CmsRangeAccrualFixedCouponPricer> pricer =
+        ext::make_shared<CmsRangeAccrualFixedCouponPricer>(volTsh);
+
+    auto startDate = Date(15, January, 2015);
+    auto endDate = Date(15, January, 2045);
+    auto period = Period(3, Months);
+    auto cal = TARGET();
+    auto endOfMonth = false;
+    Schedule couponSchedule = Schedule(startDate, endDate, period, cal, Following, Following,
+                                       DateGeneration::Backward, endOfMonth);
+
+    Real notional = 100.0;
+    Real fixedRate = 0.01;
+    auto dc = Actual360();
+
+    auto lowerTrigger = 0.0250;
+    auto upperTrigger = 0.0350;
+
+    std::vector<CmsRangeAccrualFixedCoupon> leg;
+    for (Size k = 0; k < couponSchedule.dates().size()-1; ++k) {
+        auto startDate = couponSchedule.dates()[k];
+        auto endDate = couponSchedule.dates()[k+1];
+        auto payDate = couponSchedule.dates()[k + 1];
+        leg.push_back(CmsRangeAccrualFixedCoupon(payDate, notional, fixedRate, dc, startDate,
+                                                endDate, swapIndex, lowerTrigger, upperTrigger)
+        );
+    }
+
+    for (CmsRangeAccrualFixedCoupon& cp : leg) { // make sure we get a reference and not a copy
+        cp.setPricer(pricer);
+    }
+
+    BOOST_TEST_MESSAGE("Coupon Results:");
+    for (CmsRangeAccrualFixedCoupon& cp : leg) {
+        BOOST_TEST_MESSAGE("Start: " << io::iso_date(cp.accrualStartDate())
+                                     << ", End: " << io::iso_date(cp.accrualEndDate())
+                                     << ", RA: " << cp.rangeAccrual()
+                                     << ", Rate: " << cp.rate()
+                                    << ", Amount: " << cp.amount());
+    }
+}
+
+
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -667,6 +667,7 @@
     <ClCompile Include="chooseroption.cpp" />
     <ClCompile Include="cliquetoption.cpp" />
     <ClCompile Include="cms.cpp" />
+    <ClCompile Include="cmsrangeaccrual.cpp" />
     <ClCompile Include="cms_normal.cpp" />
     <ClCompile Include="cmsspread.cpp" />
     <ClCompile Include="commodityunitofmeasure.cpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -534,6 +534,9 @@
     <ClCompile Include="fxrangeaccrual.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="cmsrangeaccrual.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="paralleltestrunner.hpp">


### PR DESCRIPTION
This PR adds functionality for fixe rate CMS range accrual coupons.
  - RA feature without convexity ajustment.
  - Do not include QuantLib VS project files.